### PR TITLE
Add clear trips functionality to clear command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -4,20 +4,22 @@ import static java.util.Objects.requireNonNull;
 
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
+import seedu.address.model.TripBook;
 
 /**
- * Clears the address book.
+ * Clears the address book and trip book.
  */
 public class ClearCommand extends Command {
 
     public static final String COMMAND_WORD = "clear";
-    public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
+    public static final String MESSAGE_SUCCESS = "Address book and Trip book has been cleared!";
 
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.setAddressBook(new AddressBook());
+        model.setTripBook(new TripBook());
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
+import seedu.address.model.TripBook;
 import seedu.address.model.UserPrefs;
 
 public class ClearCommandTest {
@@ -26,6 +27,7 @@ public class ClearCommandTest {
         Model model = new ModelManager(getTypicalAddressBook(), getTypicalTripBook(), new UserPrefs());
         Model expectedModel = new ModelManager(getTypicalAddressBook(), getTypicalTripBook(), new UserPrefs());
         expectedModel.setAddressBook(new AddressBook());
+        expectedModel.setTripBook(new TripBook());
 
         assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, expectedModel);
     }


### PR DESCRIPTION
Clear command now clears all the contacts in the address book and all the trips in the trip book. 
Useful for clearing the sample data.