### PR TITLE
Name: allow Unicode letters, digits, and common name punctuation

### DIFF
--- a/src/main/java/seedu/address/model/contact/Name.java
+++ b/src/main/java/seedu/address/model/contact/Name.java
@@ -10,13 +10,15 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Name {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+            "Names should not be blank and may only contain letters, numbers, spaces, hyphens (-), apostrophes ('), "
+                    + "and dots ("
+                    + ".).";
 
     /*
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "^[\\p{L}\\p{N} .’'\\-/]+$";
 
     public final String fullName;
 
@@ -35,17 +37,15 @@ public class Name {
      * Returns true if a given string is a valid name.
      */
     public static boolean isValidName(String test) {
-        return test.matches(VALIDATION_REGEX);
+        return !test.trim().isEmpty() && test.matches(VALIDATION_REGEX);
     }
 
 
-    @Override
-    public String toString() {
+    @Override public String toString() {
         return fullName;
     }
 
-    @Override
-    public boolean equals(Object other) {
+    @Override public boolean equals(Object other) {
         if (other == this) {
             return true;
         }
@@ -59,8 +59,7 @@ public class Name {
         return fullName.equals(otherName.fullName);
     }
 
-    @Override
-    public int hashCode() {
+    @Override public int hashCode() {
         return fullName.hashCode();
     }
 

--- a/src/test/java/seedu/address/model/contact/NameTest.java
+++ b/src/test/java/seedu/address/model/contact/NameTest.java
@@ -24,18 +24,27 @@ public class NameTest {
         // null name
         assertThrows(NullPointerException.class, () -> Name.isValidName(null));
 
-        // invalid name
+        // invalid names
         assertFalse(Name.isValidName("")); // empty string
         assertFalse(Name.isValidName(" ")); // spaces only
-        assertFalse(Name.isValidName("^")); // only non-alphanumeric characters
-        assertFalse(Name.isValidName("peter*")); // contains non-alphanumeric characters
+        assertFalse(Name.isValidName("^")); // only invalid symbol
+        assertFalse(Name.isValidName("peter*")); // contains invalid symbol
+        assertFalse(Name.isValidName("!!!")); // only invalid symbols
+        assertFalse(Name.isValidName("John@Doe")); // disallowed special characters
 
-        // valid name
+        // valid names
         assertTrue(Name.isValidName("peter jack")); // alphabets only
         assertTrue(Name.isValidName("12345")); // numbers only
         assertTrue(Name.isValidName("peter the 2nd")); // alphanumeric characters
         assertTrue(Name.isValidName("Capital Tan")); // with capital letters
         assertTrue(Name.isValidName("David Roger Jackson Ray Jr 2nd")); // long names
+        assertTrue(Name.isValidName("Jeanne d’Arc")); // with curly apostrophe
+        assertTrue(Name.isValidName("Tharman s/o Soham")); // with slash
+        assertTrue(Name.isValidName("Jean-Luc Picard")); // with hyphen
+        assertTrue(Name.isValidName("O'Connor")); // with straight apostrophe
+        assertTrue(Name.isValidName("Dr. John A. Smith")); // with dots
+        assertTrue(Name.isValidName("李小龙")); // Unicode characters (Chinese)
+        assertTrue(Name.isValidName("Nguyễn Văn A")); // Unicode with accents
     }
 
     @Test


### PR DESCRIPTION
Closes #163. 

Allow these characters in Contact name. Note even though `Name` allows `/`, the command parser will not allow it because `/` is a reserved character for commands.
| Pattern     | Meaning                                               |
|-------------|--------------------------------------------------------|
| `\p{L}`     | Any Unicode letter (e.g., A–Z, á, 世)                  |
| `\p{N}`     | Any Unicode digit (e.g., 0–9, ١, 一)                   |
| space       | Literal space ( )                                     |
| `.`         | Literal dot                                           |
| `'` and `’` | Curly and straight apostrophes                        |
| `-`         | Hyphen                                                |
| `/`         | Forward slash                                         |